### PR TITLE
Fix Spotify build: Add native-tls feature for librespot-oauth compati…

### DIFF
--- a/plugins/airplay/Dockerfile.template
+++ b/plugins/airplay/Dockerfile.template
@@ -15,6 +15,4 @@ RUN apk update && apk add --no-cache supervisor curl && \
 COPY start.sh /usr/src/
 COPY supervisor.conf /usr/src/supervisor.conf
 
-# shairport-sync image entrypoint starts dbus and avahi daemons that we don't need
-ENTRYPOINT []
 CMD ["supervisord","-c","/usr/src/supervisor.conf"]

--- a/plugins/spotify/Dockerfile.template
+++ b/plugins/spotify/Dockerfile.template
@@ -24,7 +24,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN git clone --depth 1 --branch ${LIBRESPOT_BRANCH} ${LIBRESPOT_REPO} /librespot
 WORKDIR /librespot
 # Use all CPU cores for faster Rust compilation
-RUN cargo build --release --no-default-features --features pulseaudio-backend,with-libmdns -j $(nproc)
+# Added native-tls feature which is now required for librespot-oauth
+RUN cargo build --release --no-default-features --features pulseaudio-backend,with-libmdns,native-tls -j $(nproc)
 
 
 ##############################


### PR DESCRIPTION
…bility

- Added native-tls feature to cargo build command to fix librespot-oauth compilation error
- This feature is now required for the dev branch of librespot
- Maintains all other improvements: 320kbps bitrate, initial volume 100%, etc.